### PR TITLE
remove `struct Param`

### DIFF
--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -575,14 +575,14 @@ Encrypted input shares are structured as follows:
 
 ~~~
 struct {
-  HpkeConfigId config_id;
+  HpkeConfigId aggregator_config_id;
   opaque enc<1..2^16-1>;
   opaque payload<1..2^16-1>;
 } EncryptedInputShare;
 ~~~
 
-* `config_id` is equal to `HpkeConfig.id`, where `HpkeConfig` is the key config
-  of the aggregator receiving the input share.
+* `aggregator_config_id` is equal to `HpkeConfig.id`, where `HpkeConfig` is the
+  key config of the aggregator receiving the input share.
 * `enc` is the encapsulated HPKE context, used by the aggregator to decrypt its
   input share.
 * `payload` is the encrypted input share.
@@ -898,7 +898,7 @@ body consisting of the following structure:
 struct {
   HpkeConfigId collector_hpke_config_id;
   opaque enc<1..2^16-1>;
-  opaque encrypted_output_share<1..2^16>;
+  opaque payload<1..2^16>;
 } EncryptedOutputShare;
 ~~~
 
@@ -906,8 +906,7 @@ struct {
   corresponding to `CollectReq.task_id`.
 * `enc` is the encapsulated HPKE context, used by the collector to decrypt the
   output share.
-* `encrypted_output_share` is an encrypted `OutputShare`, whose structure is
-  given below.
+* `payload` is an encrypted `OutputShare`.
 
 The leader uses the helper's output share response to respond to the collector's
 collect request (see {{pa-collect}}).


### PR DESCRIPTION
`Param` is never transmitted over the wire, nor do we otherwise depend
on is structure, so this commit removes that struct definition and
instead enumerates the pre-negotiated task parameters each participant
must hold, leaving implementations free to store, represent and transmit
those parameters any way they wish. `TaskId` is still around, but
instead of being a SHA-256 over the serialiation of Param, it's now just
32 random bytes.

Resolves #104