### PR TITLE
Add share-counting attacks to threat model

### DIFF
--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1146,7 +1146,9 @@ absence of a share for a given user is sensitive.
 1. If computed over a sufficient number of input shares, output shares reveal
    nothing about either the inputs or the participating clients.
 1. Clients can ensure that aggregate counts are non-sensitive by generating
-   input independently of user behavior.
+   input independently of user behavior. For example, a client should periodically
+   upload a report even if the event that the task is tracking has not occurred, so
+   that the absence of reports cannot be distinguished from their presence.
 1. Bogus inputs can be generated that encode "null" shares that do not affect
    the aggregate output, but mask the total number of true inputs.
      * Either leaders or clients can generate these inputs to mask the total

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1155,7 +1155,7 @@ absence of a share for a given user is sensitive.
        indistinguishable from true inputs (size, metadata, etc).
       
 [OPEN ISSUE: Define what "null" shares are. They should be defined such that
-inserting null shares into an aggregation is effectively a no-op]
+inserting null shares into an aggregation is effectively a no-op. See issue#98.]
 
 ### Leader
 

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1145,10 +1145,17 @@ absence of a share for a given user is sensitive.
    shares.
 1. If computed over a sufficient number of input shares, output shares reveal
    nothing about either the inputs or the participating clients.
-1. Leaders can inject bogus "null" shares that do not affect the aggregate
-   output but mask the total number of shares to non-leader aggregators.
-1. Clients can inject bogus "null" shares that do not affect the aggregate
-   output but mask the total number of shares all aggregators.
+1. Clients can ensure that aggregate counts are non-sensitive by generating
+   input independently of user behavior.
+1. Bogus inputs can be generated that encode "null" shares that do not affect
+   the aggregate output, but mask the total number of true inputs.
+     * Either leaders or clients can generate these inputs to mask the total
+       number from non-leader aggregators or all the aggregators, respectively.
+     * In either case, care must be taken to ensure that bogus inputs are
+       indistinguishable from true inputs.
+      
+[OPEN ISSUE: Define what "null" shares are. They should be defined such that
+inserting null shares into an aggregation is effectively a no-op]
 
 ### Leader
 

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1134,6 +1134,9 @@ to emit output shares.
 1. Input validity proof forging. Any aggregator can collude with a malicious
 client to craft a proof that will fool honest aggregators into accepting
 invalid input.
+1. Aggregators can count the total number of input shares, which could
+compromise user privacy (and differential privacy {{dp}}) if the presence or
+absence of a share for a given user is sensitive.
 
 #### Mitigations
 
@@ -1142,6 +1145,10 @@ invalid input.
    shares.
 1. If computed over a sufficient number of input shares, output shares reveal
    nothing about either the inputs or the participating clients.
+1. Leaders can inject bogus "null" shares that do not affect the aggregate
+   output but mask the total number of shares to non-leader aggregators.
+1. Clients can inject bogus "null" shares that do not affect the aggregate
+   output but mask the total number of shares all aggregators.
 
 ### Leader
 

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1152,7 +1152,7 @@ absence of a share for a given user is sensitive.
      * Either leaders or clients can generate these inputs to mask the total
        number from non-leader aggregators or all the aggregators, respectively.
      * In either case, care must be taken to ensure that bogus inputs are
-       indistinguishable from true inputs.
+       indistinguishable from true inputs (size, metadata, etc).
       
 [OPEN ISSUE: Define what "null" shares are. They should be defined such that
 inserting null shares into an aggregation is effectively a no-op]

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1152,7 +1152,8 @@ absence of a share for a given user is sensitive.
      * Either leaders or clients can generate these inputs to mask the total
        number from non-leader aggregators or all the aggregators, respectively.
      * In either case, care must be taken to ensure that bogus inputs are
-       indistinguishable from true inputs (size, metadata, etc).
+       indistinguishable from true inputs (metadata, etc), especially when
+       constructing timestamps on reports.
       
 [OPEN ISSUE: Define what "null" shares are. They should be defined such that
 inserting null shares into an aggregation is effectively a no-op. See issue#98.]


### PR DESCRIPTION
Aggregators merely counting the number of input shares could compromise
user privacy in some circumstances (namely, it can break differential privacy
if the number of records per user is not constant).

This attack only applies to aggregators who can count the number of shares,
so any protection still holds on the collector side.

To address this attack, there are two possible mitigations, which both involve
adding noise to the total number of input shares. This should be possible to
do with "null" shares that don't affect aggregate output (i.e. inserting 0 into
sums).