### PR TITLE
update references to "prio-documents"

### DIFF
--- a/.note.xml
+++ b/.note.xml
@@ -3,5 +3,5 @@
     mailing list (),
   which is archived at <eref target=""/>.</t>
 <t>Source for this draft and an issue tracker can be found at
-  <eref target="https://github.com/abetterinternet/prio-documents"/>.</t>
+  <eref target="https://github.com/abetterinternet/ppm-specification"/>.</t>
 </note>

--- a/.targets.mk
+++ b/.targets.mk
@@ -1,4 +1,4 @@
-TARGETS_DRAFTS := draft-ppm-protocol 
+TARGETS_DRAFTS := draft-ppm-protocol
 TARGETS_TAGS := 
 draft-ppm-protocol-00.md: draft-ppm-protocol.md
 	sed -e 's/draft-ppm-protocol-latest/draft-ppm-protocol-00/g' $< >$@

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/abetterinternet/prio-documents/blob/i-d-format/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/abetterinternet/ppm-specification/blob/i-d-format/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Private Data Aggregation Protocol
+# Privacy Preserving Measurement Protocol
 
-This is the working area for the individual Internet-Draft, "Private Data Aggregation Protocol".
+This is the working area for the individual Internet-Draft, "Privacy Preserving Measurement Protocol".
 
-* [Editor's Copy](https://abetterinternet.github.io/prio-documents/#go.draft-ppm-protocol.html)
+* [Editor's Copy](https://abetterinternet.github.io/ppm-specification/#go.draft-ppm-protocol.html)
 * [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ppm-protocol)
-* [Compare Editor's Copy to Individual Draft](https://abetterinternet.github.io/prio-documents/#go.draft-ppm-protocol.diff)
+* [Compare Editor's Copy to Individual Draft](https://abetterinternet.github.io/ppm-specification/#go.draft-ppm-protocol.diff)
 
 ## Building the Draft
 
@@ -21,4 +21,4 @@ This requires that you have the necessary software installed.  See
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/abetterinternet/prio-documents/blob/i-d-format/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/abetterinternet/ppm-specification/blob/i-d-format/CONTRIBUTING.md).

--- a/bof-request.txt
+++ b/bof-request.txt
@@ -51,6 +51,6 @@ will instead use algorithms defined by the CFRG.
 
 ## Links to the mailing list, draft charter if any, relevant Internet-Drafts, etc.
    - Mailing List: ppm@ietf.org, https://www.ietf.org/mailman/listinfo/ppm
-   - Draft charter: https://github.com/abetterinternet/prio-documents/blob/main/charter.md
+   - Draft charter: https://github.com/abetterinternet/ppm-specification/blob/main/charter.md
    - Relevant drafts:
-      - https://abetterinternet.github.io/prio-documents/draft-pda-protocol.html
+      - https://abetterinternet.github.io/ppm-specification/draft-pda-protocol.html

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -267,7 +267,7 @@ The overall system architecture is shown in {{pa-topology}}.
 {: #pa-topology title="System Architecture"}
 
 [[OPEN ISSUE: This shows two helpers, but the document only allows one for now.
-https://github.com/abetterinternet/prio-documents/issues/117]]
+https://github.com/abetterinternet/ppm-specification/issues/117]]
 
 
 The main participants in the protocol are as follows:
@@ -457,7 +457,7 @@ Time uint64; /* seconds elapsed since start of UNIX epoch */
 * `collector_config`: The HPKE configuration of the collector (described in
   {{key-config}}). Putting the collector's HPKE configuration directly in
   `struct PPMParam` absolves collectors of the burden of operating an HTTP
-  server. See [#102](https://github.com/abetterinternet/prio-documents/issues/102)
+  server. See [#102](https://github.com/abetterinternet/ppm-specification/issues/102)
   for discussion.
 * `max_batch_lifetime`: The maximum number of times a batch of reports may be
   used in a collect request.
@@ -1394,7 +1394,7 @@ the protocol runs do not agree, then participants know that at least one
 aggregator is defective, and it may be possible to identify the defector (i.e.,
 if a majority of runs agree, and a single aggregator appears in every run that
 disagrees). See
-[#22](https://github.com/abetterinternet/prio-documents/issues/22) for
+[#22](https://github.com/abetterinternet/ppm-specification/issues/22) for
 discussion.
 
 ## Infrastructure diversity


### PR DESCRIPTION
The repo was renamed to "ppm-specification". This commit replaces
various occurences of the old repo's name, and also updated README.md to
reflect the current name of the protocol.