### PR TITLE
Clarify timing of report aggregations & purpose of anti-replay.

### DIFF
--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -776,10 +776,13 @@ and constructs its response to the aggregate request.
 #### Leader State
 
 The leader is required to issue aggregate requests in order, but reports are
-likely to arrive out-of-order. The leader SHOULD buffer reports for a time
-period proportional to the batch window before issuing the first aggregate
-request. Failure to do so will result in out-of-order reports being dropped by
-the helper.
+likely to arrive out-of-order. The leader MUST store reports until their
+timestamp is sufficiently far in the past (proportional to the batch window)
+before including them in an aggregate request. Failure to do so will result in
+reports being dropped by the helper. The leader SHOULD NOT accept reports from
+clients timestamped too far into the future (proportional to the batch window).
+Failure to do so will result in reports from malicious, misconfigured, or
+malfunctioning clients being stored for an arbitrary amount of time.
 
 #### Helper State
 
@@ -955,10 +958,11 @@ aggregator has validated and which fall in the batch interval of the request.
 
 ### Anti-replay {#anti-replay}
 
-Using a report multiple times within a single batch, or using the same report in
-multiple batches, is considered a privacy violation. To prevent such replay
-attacks, this specification defines a total ordering on reports that aggregators
-can use to ensure that reports are aggregated once.
+Using a client-provided report multiple times within a single batch, or using
+the same report in multiple batches, may allow a server to learn information
+about the client's measurement. To prevent such replay attacks, this
+specification defines a total ordering on reports that aggregators can use to
+ensure that reports are aggregated once.
 
 Aggregate requests are ordered as follows: We say that a report `R2` follows
 report `R1` if either `R2.time > R1.time` or `R2.time == R1.time` and `R2.nonce


### PR DESCRIPTION
As previously written, the timing of report aggregations would allow
aggregation of reports with timestamps far into the future, which would
allow a single client reporting a timestamp of INT_MAX to DOS the
aggregation system due to the way timestamps are used in the anti-replay
mechanism. Given the severity of not following this portion of the
specification, I upgrade the SHOULD to a MUST as well.

Fixes #153.