### PR TITLE
Remove .targets.mk

### DIFF
--- a/.targets.mk
+++ b/.targets.mk
@@ -1,4 +1,0 @@
-TARGETS_DRAFTS := draft-gpew-priv-ppm
-TARGETS_TAGS := 
-draft-gpew-priv-ppm-00.md: draft-gpew-priv-ppm.md
-	sed -e 's/draft-gpew-priv-ppm-latest/draft-gpew-priv-ppm-00/g' $< >$@


### PR DESCRIPTION
This never needed to be checked, and `make` overwrites it every time you
build the doc.