### PR TITLE
Add HMAC-SHA256 tag to all Request/Response messages.

### DIFF
--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -493,9 +493,6 @@ of the aggregators is configured with following parameters:
   specified. See issue#161.]
 * `agg_auth_key`: A key for HMAC-SHA256 {{?RFC2104}} shared by the aggregators and
   used for message authentication during the aggregation flow.
-* `collect_auth_key`: A key for HMAC-SHA256 {{?RFC2104}} shared by the
-  aggregators and the collector and used for message authentication during the
-  collect flow.
 
 Finally, the collector is configured with the HPKE secret key corresponding to
 `collector_hpke_config`.
@@ -1291,7 +1288,6 @@ struct {
   TaskID task_id;
   Interval batch_interval;
   opaque agg_param<0..2^16-1>;
-  opaque tag[32];
 } CollectReq;
 ~~~
 
@@ -1300,9 +1296,6 @@ The named parameters are:
 * `task_id`, the PPM task ID.
 * `batch_interval`, the request's batch interval.
 * `agg_param`, an aggregation parameter for the VDAF being executed.
-* `tag`, an HMAC-SHA256 tag over the serialized message, excluding the `tag`
-   field itself, computed using the `collect_auth_key` shared by the leader
-   and the collector.
 
 To make a collect request, the collector issues a POST request to
 `[leader]/collect`, where `[leader]` is the leader's endpoint URL with a
@@ -1346,15 +1339,12 @@ message:
 ~~~
 struct {
   HpkeCiphertext encrypted_agg_shares shares<1..2^16-1>;
-  opaque tag[32];
 } CollectResp;
 ~~~
 
 The `encrypted_agg_shares` field is the vector of encrypted aggregate shares.
 They MUST appear in the same order as the aggregator endpoints list of the task
-parameters. `tag` is an HMAC-SHA256 tag over the serialized message, excluding
-the `tag` field itself, computed using the `collect_auth_key` shared by the
-leader and the collector. 
+parameters.
 
 [OPEN ISSUE: What should the collector do if it can't compute the aggregate
 result?]


### PR DESCRIPTION
Previously these were inconsistently applied between different messages.
I introduce a new `collect_auth_key`, distinct from the existing
`agg_auth_key`, for collect messages.

I think we could get away with only authenticating the request messages
(leaning on TLS to provide authentication for the responses); I'd be
amenable to that, but my understanding is that we don't want to rely on
the properties of the underlying channel, so I went ahead and specified
authentication tags for both request & response messages.