### PR TITLE
base64-encode TaskID in problem details JSON object

### DIFF
--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -385,8 +385,8 @@ not listed in the appropriate IANA registry (see {{ppm-urn-space}}). Clients
 SHOULD display the "detail" field of all errors. The "instance" value MUST be
 the endpoint to which the request was targeted. The problem document MUST also
 include a "taskid" member which contains the associated PPM task ID, encoded
-with base64 {{!RFC4648}} (this value is always known, see
-{{task-configuration}}).
+with base64 using the standard alphabet {{!RFC4648}} (this value is always
+known, see {{task-configuration}}).
 
 In the remainder of this document, we use the tokens in the table above to refer
 to error types, rather than the full URNs. For example, an "error of type

--- a/draft-gpew-priv-ppm.md
+++ b/draft-gpew-priv-ppm.md
@@ -384,8 +384,9 @@ than those defined above. Servers MUST NOT use the PPM URN namespace for errors
 not listed in the appropriate IANA registry (see {{ppm-urn-space}}). Clients
 SHOULD display the "detail" field of all errors. The "instance" value MUST be
 the endpoint to which the request was targeted. The problem document MUST also
-include a "taskid" member which contains the associated PPM task ID (this value
-is always known, see {{task-configuration}}).
+include a "taskid" member which contains the associated PPM task ID, encoded
+with base64 {{!RFC4648}} (this value is always known, see
+{{task-configuration}}).
 
 In the remainder of this document, we use the tokens in the table above to refer
 to error types, rather than the full URNs. For example, an "error of type


### PR DESCRIPTION
Section 3.1 says to include the PPM task ID in a field on the problem details JSON object, but the task ID may be any 32 byte value, and may not be representable as a Unicode string. I propose that we base64-encode the task ID here to resolve this.